### PR TITLE
Update alerts.py to add discord alerter

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -23,6 +23,7 @@ import boto3
 import requests
 import stomp
 from exotel import Exotel
+from discord_webhook import DiscordWebhook, DiscordEmbed
 from jira.client import JIRA
 from jira.exceptions import JIRAError
 from requests.auth import HTTPProxyAuth
@@ -2170,3 +2171,64 @@ class HiveAlerter(Alerter):
             'type': 'hivealerter',
             'hive_host': self.rule.get('hive_connection', {}).get('hive_host', '')
         }
+class DiscordAlerter(Alerter):
+
+    required_options = frozenset(['discord_webhook_url'])
+
+    def __init__(self,rule):
+        super(DiscordAlerter, self).__init__(rule)
+        self.discord_webhook_url = self.rule['discord_webhook_url']
+        self.discord_emoji_title = self.rule.get('discord_emoji_title', ':warning:')
+        self.discord_http_proxy = self.rule.get('discord_http_proxy', None)
+        self.discord_https_proxy = self.rule.get('discord_https_proxy', None)
+        self.discord_proxy_login = self.rule.get('discord_proxy_login', None)
+        self.discord_proxy_password = self.rule.get('discord_proxy_password', None)
+        self.discord_embed_color = self.rule.get('discord_embed_color', 0xffffff)
+        self.discord_embed_footer = self.rule.get('discord_embed_footer', None)
+        self.discord_embed_icon_url = self.rule.get('discord_embed_icon_url', None)
+
+    def alert(self, matches):
+        body = ''
+        title = u'%s' % (self.create_title(matches))
+        for match in matches:
+            body += unicode(BasicMatchString(self.rule, match))
+            if len(matches) > 1:
+                body += '\n----------------------------------------\n'
+        if len(body) > 2047:
+                body = body[0:1950] + '\n *message was cropped according to discord embed description limits!* '
+
+        body += '```'
+
+        proxies = {} if self.discord_http_proxy or self.discord_https_proxy else None
+        proxies['http'] = '%s' % (self.discord_http_proxy) if self.discord_http_proxy else None
+        proxies['https'] = '%s' % (self.discord_https_proxy) if self.discord_https_proxy else None
+        auth = HTTPProxyAuth(self.discord_proxy_login, self.discord_proxy_password) if self.discord_proxy_login else None
+        headers = {"Content-Type": "application/json"}
+
+        data = {}
+        data["content"] = "%s %s %s" % (self.discord_emoji_title, title, self.discord_emoji_title)
+        data["embeds"] = []
+        embed = {}
+        embed["description"] = "%s" % (body)
+        embed["color"] = (self.discord_embed_color)
+
+        if self.discord_embed_footer:
+                embed["footer"] = {}
+                embed["footer"]["text"] = (self.discord_embed_footer)
+                embed["footer"]["icon_url"] = (self.discord_embed_icon_url) if self.discord_embed_icon_url else None
+        else:
+                None
+
+        data["embeds"].append(embed)
+
+        try:
+                result = requests.post(self.discord_webhook_url, data=json.dumps(data), headers=headers, proxies=proxies)
+        except RequestException as e:
+                raise EAException("Error posting to Discord: %s. Details: %s" % (e, "" if e.response is None else e.response.text))
+
+        elastalert_logger.info(
+                "Alert sent to the webhook %s" % self.discord_webhook_url)
+
+    def get_info(self):
+            return {'type': 'discord',
+                    'discord_webhook_url': self.discord_webhook_url}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -349,3 +349,6 @@ properties:
   zbx_sender_port: {type: integer}
   zbx_host: {type: string}
   zbx_item: {type: string}
+
+  ### Discord
+  discord_webhook_url: {type: string}


### PR DESCRIPTION
Add discord module needed for the alerter to work properly. (need ``` pip install disword-webhook"```)

Add a new alerter AlerterDiscord at the end of the file.

This alerter new at least the url of the webhook the alerter will use to process the alert.
I add many options available ;
- self.discord_emoji_title : Option to replace the static ⚠️ in the title of the message posted (tested)
- self.discord_http_proxy and self.discord_https_proxy : Used to make the alerter work behind a proxy (tested)
- self.discord_proxy_login and discord_proxy_password : Used for the alerter to authenticate himself behind a proxy (not tested)
- self.discord_embed_color : Used to choose the color of the embed content send by the alerter (tested)
- self.discord_embed_footer : Used to add content on the footer of the embed content (tested)
- self.discord_embed_icon_url : Used to add an icon in the footer of the embed content (tested)
I also setup the crop body to 2047 because the limit of the description field in an discord message if 2048 length long. I then update the message displayed if it is too long (not tested)